### PR TITLE
Fix multiple monitor issues

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,16 +80,6 @@ func (m *neko) Update() error {
 	// or randomly travelling to another monitor
 	m.x = max(0, min(m.x, monitorWidth))
 	m.y = max(0, min(m.y, monitorHeight))
-	if m.x < 0 {
-		m.x = 0
-	} else if m.x >= monitorWidth {
-		m.x = monitorWidth
-	}
-	if m.y < 0 {
-		m.y = 0
-	} else if m.y >= monitorHeight {
-		m.y = monitorHeight
-	}
 	ebiten.SetWindowPosition(m.x, m.y)
 
 	mx, my := ebiten.CursorPosition()

--- a/main.go
+++ b/main.go
@@ -78,6 +78,8 @@ func (m *neko) Update() error {
 	}
 	// Prevents neko from being stuck on the side of the screen
 	// or randomly travelling to another monitor
+	m.x = max(0, min(m.x, monitorWidth))
+	m.y = max(0, min(m.y, monitorWidth))
 	if m.x < 0 {
 		m.x = 0
 	} else if m.x >= monitorWidth {

--- a/main.go
+++ b/main.go
@@ -51,6 +51,8 @@ var (
 	width  = 32
 	height = 32
 
+	monitorWidth, monitorHeight = ebiten.ScreenSizeInFullscreen()
+
 	cfg = &Config{}
 
 	currentplayer *audio.Player = nil
@@ -60,7 +62,7 @@ func (m *neko) Layout(outsideWidth, outsideHeight int) (int, int) {
 	return width, height
 }
 
-func playsound(sound []byte) {
+func playSound(sound []byte) {
 	if currentplayer != nil && currentplayer.IsPlaying() {
 		currentplayer.Close()
 	}
@@ -72,7 +74,19 @@ func playsound(sound []byte) {
 func (m *neko) Update() error {
 	m.count++
 	if m.state == 10 && m.count == m.min {
-		playsound(mSound["idle3"])
+		playSound(mSound["idle3"])
+	}
+	// Prevents neko from being stuck on the side of the screen
+	// or randomly travelling to another monitor
+	if m.x < 0 {
+		m.x = 0
+	} else if m.x >= monitorWidth {
+		m.x = monitorWidth
+	}
+	if m.y < 0 {
+		m.y = 0
+	} else if m.y >= monitorHeight {
+		m.y = monitorHeight
 	}
 	ebiten.SetWindowPosition(m.x, m.y)
 
@@ -98,11 +112,8 @@ func (m *neko) Update() error {
 	}
 
 	if m.state >= 13 {
-		playsound(mSound["awake"])
+		playSound(mSound["awake"])
 	}
-	m.state = 0
-	m.min = 8
-	m.max = 16
 	m.catchCursor(x, y)
 	return nil
 }
@@ -134,6 +145,9 @@ func (m *neko) stayIdle() {
 }
 
 func (m *neko) catchCursor(x, y int) {
+	m.state = 0
+	m.min = 8
+	m.max = 16
 	tr := 0.0
 	// get mouse direction
 	r := math.Atan2(float64(y), float64(x))
@@ -206,7 +220,7 @@ func (m *neko) Draw(screen *ebiten.Image) {
 			m.state++
 			switch m.state {
 			case 13:
-				playsound(mSound["sleep"])
+				playSound(mSound["sleep"])
 			}
 		}
 	}
@@ -270,10 +284,9 @@ func main() {
 	// So let's do this at the start.
 	audio.CurrentContext().NewPlayerFromBytes([]byte{}).Play()
 
-	sw, sh := ebiten.ScreenSizeInFullscreen()
 	n := &neko{
-		x:   sw / 2,
-		y:   sh / 2,
+		x:   monitorWidth / 2,
+		y:   monitorHeight / 2,
 		min: 8,
 		max: 16,
 	}

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func (m *neko) Update() error {
 	// Prevents neko from being stuck on the side of the screen
 	// or randomly travelling to another monitor
 	m.x = max(0, min(m.x, monitorWidth))
-	m.y = max(0, min(m.y, monitorWidth))
+	m.y = max(0, min(m.y, monitorHeight))
 	if m.x < 0 {
 		m.x = 0
 	} else if m.x >= monitorWidth {


### PR DESCRIPTION
Since it's not possible to make neko work well with multiple monitors using Ebitengine, I implemented a workaround which stops neko from travelling to negative horizontal or vertical positions(which makes it stuck on the side of the screen until it's position return to the positive value) while keeping mouse on the other monitor and stops it from randomly travelling to another monitor(more about it below).  I used a global variable for it since it doesn't change and there are other global variables already. 

How does neko travel to another monitor? I have two monitors in a setup like this: 1080x1920 and 2560x1440. I start neko on 2560x1440 display. If neko horizontal position goes above 1440(for example when I keep cursor on the 1080x1920 monitor) then neko automatically travels to the 1080x1920 monitor(since it's the only available monitor with horizontal value this high).