### PR TITLE
feat: multi-monitor support, configurable speed via neko.ini, and animation stability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,15 +8,12 @@ require (
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ebitengine/gomobile v0.0.0-20260211053922-3d992dae95d1 // indirect
 	github.com/ebitengine/hideconsole v1.0.0 // indirect
 	github.com/ebitengine/oto/v3 v3.4.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/jezek/xgb v1.3.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 crg.eti.br/go/config v1.5.0 h1:UiHy9zAhFj5LxKPm7TwgVMc7VBxtYWpFcGtXKQHCyf0=
 crg.eti.br/go/config v1.5.0/go.mod h1:Wk/f8SMC4nwlUJu0gRqUA6IOCJ/vMDMlaOvKaF6KqKI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ebitengine/gomobile v0.0.0-20260211053922-3d992dae95d1 h1:U8WldvN7/4cgo65U2fr2urv43/yhqYOK5FegFPPfI4M=
 github.com/ebitengine/gomobile v0.0.0-20260211053922-3d992dae95d1/go.mod h1:J7sDBRQG9pJGMa9Z+h8l3flwk0yEKDzWeR57vA1LI5U=
@@ -14,6 +15,7 @@ github.com/hajimehoshi/ebiten/v2 v2.9.8 h1:xI0hIctuTMjFFk8lqEcUzoLjFy8d/FOBa9PDT
 github.com/hajimehoshi/ebiten/v2 v2.9.8/go.mod h1:DAt4tnkYYpCvu3x9i1X/nK/vOruNXIlYq/tBXxnhrXM=
 github.com/jezek/xgb v1.3.0 h1:Wa1pn4GVtcmNVAVB6/pnQVJ7xPFZVZ/W1Tc27msDhgI=
 github.com/jezek/xgb v1.3.0/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
@@ -22,7 +24,10 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/image v0.36.0 h1:Iknbfm1afbgtwPTmHnS2gTM/6PPZfH+z2EFuOkSbqwc=
+golang.org/x/image v0.36.0/go.mod h1:YsWD2TyyGKiIX1kZlu9QfKIsQ4nAAK9bdgdrIsE7xy4=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
@@ -31,4 +36,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/ini.v1 v1.67.1 h1:tVBILHy0R6e4wkYOn3XmiITt/hEVH4TFMYvAX2Ytz6k=
 gopkg.in/ini.v1 v1.67.1/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"embed"
 	"fmt"
@@ -10,7 +11,10 @@ import (
 	"io/fs"
 	"log"
 	"math"
+	"os"
 	"path"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -18,9 +22,6 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/audio"
 	"github.com/hajimehoshi/ebiten/v2/audio/wav"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
-
-	"crg.eti.br/go/config"
-	_ "crg.eti.br/go/config/ini"
 )
 
 type neko struct {
@@ -32,8 +33,9 @@ type neko struct {
 	min        int
 	max        int
 	state      int
-	sprite     string
-	lastSprite string
+	sprite        string
+	lastSprite    string
+	lastDirection string
 	img        *ebiten.Image
 
 	cfg           *Config
@@ -44,10 +46,60 @@ type neko struct {
 }
 
 type Config struct {
-	Speed            float64 `cfg:"speed" cfgDefault:"2.0" cfgHelper:"The speed of the cat."`
-	Scale            float64 `cfg:"scale" cfgDefault:"2.0" cfgHelper:"The scale of the cat."`
-	Quiet            bool    `cfg:"quiet" cfgDefault:"false" cfgHelper:"Disable sound."`
-	MousePassthrough bool    `cfg:"mousepassthrough" cfgDefault:"false" cfgHelper:"Enable mouse passthrough."`
+	Speed            float64
+	Scale            float64
+	Quiet            bool
+	MousePassthrough bool
+}
+
+// loadConfig reads neko.ini from the same directory as the executable.
+// Supported keys: speed, scale, quiet, mousepassthrough
+func loadConfig() *Config {
+	cfg := &Config{
+		Speed: 2.0,
+		Scale: 2.0,
+	}
+
+	exePath, err := os.Executable()
+	if err != nil {
+		return cfg
+	}
+	iniPath := filepath.Join(filepath.Dir(exePath), "neko.ini")
+
+	f, err := os.Open(iniPath)
+	if err != nil {
+		return cfg
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, ";") || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		val := strings.TrimSpace(parts[1])
+		switch key {
+		case "speed":
+			if v, err := strconv.ParseFloat(val, 64); err == nil {
+				cfg.Speed = v
+			}
+		case "scale":
+			if v, err := strconv.ParseFloat(val, 64); err == nil {
+				cfg.Scale = v
+			}
+		case "quiet":
+			cfg.Quiet = val == "true" || val == "1"
+		case "mousepassthrough":
+			cfg.MousePassthrough = val == "true" || val == "1"
+		}
+	}
+	return cfg
 }
 
 const (
@@ -96,15 +148,7 @@ func (m *neko) Update() error {
 		m.playSound("idle3")
 	}
 
-	// Prevents neko from being stuck on the side of the screen
-	// or randomly travelling to another monitor
-	monitorWidth, monitorHeight := ebiten.Monitor().Size()
-	windowWidth, windowHeight := ebiten.WindowSize()
-	maxX := float64(max(0, monitorWidth-windowWidth))
-	maxY := float64(max(0, monitorHeight-windowHeight))
-
-	m.x = max(0, min(m.x, maxX))
-	m.y = max(0, min(m.y, maxY))
+	// Move the window to follow the cat position (no clamping — allows multi-monitor roaming).
 	ebiten.SetWindowPosition(int(math.Round(m.x)), int(math.Round(m.y)))
 
 	mx, my := ebiten.CursorPosition()
@@ -159,7 +203,45 @@ func (m *neko) catchCursor(x, y int) {
 
 	// get mouse direction
 	r := math.Atan2(float64(y), float64(x))
-	a := math.Mod((r/math.Pi*180)+360, 360) // Normazing angle to [0, 360)
+	a := math.Mod((r/math.Pi*180)+360, 360) // Normalizing angle to [0, 360)
+
+	// Hysteresis: if the angle is within 5° of any direction boundary,
+	// keep the last direction to prevent flickering between animations.
+	const hysteresis = 5.0
+	boundaries := [8]float64{22.5, 67.5, 112.5, 157.5, 202.5, 247.5, 292.5, 337.5}
+	for _, b := range boundaries {
+		diff := math.Abs(a - b)
+		if diff > 180 {
+			diff = 360 - diff
+		}
+		if diff < hysteresis && m.lastDirection != "" {
+			m.sprite = m.lastDirection
+			// Still move in the last direction so the cat doesn't freeze
+			switch m.lastDirection {
+			case "up":
+				m.y -= m.cfg.Speed
+			case "upright":
+				m.x += m.cfg.Speed / math.Sqrt2
+				m.y -= m.cfg.Speed / math.Sqrt2
+			case "right":
+				m.x += m.cfg.Speed
+			case "downright":
+				m.x += m.cfg.Speed / math.Sqrt2
+				m.y += m.cfg.Speed / math.Sqrt2
+			case "down":
+				m.y += m.cfg.Speed
+			case "downleft":
+				m.x -= m.cfg.Speed / math.Sqrt2
+				m.y += m.cfg.Speed / math.Sqrt2
+			case "left":
+				m.x -= m.cfg.Speed
+			case "upleft":
+				m.x -= m.cfg.Speed / math.Sqrt2
+				m.y -= m.cfg.Speed / math.Sqrt2
+			}
+			return
+		}
+	}
 
 	switch {
 	case a <= 292.5 && a > 247.5: // up
@@ -191,6 +273,7 @@ func (m *neko) catchCursor(x, y int) {
 		m.y -= m.cfg.Speed / math.Sqrt2
 		m.sprite = "upleft"
 	}
+	m.lastDirection = m.sprite
 }
 
 func (m *neko) Draw(screen *ebiten.Image) {
@@ -275,13 +358,7 @@ func loadAssets(assetsFS fs.FS, sampleRate int) (map[string]*ebiten.Image, map[s
 }
 
 func main() {
-	cfg := &Config{}
-
-	config.PrefixEnv = "NEKO"
-	config.File = "neko.ini"
-	if err := config.Parse(cfg); err != nil {
-		log.Fatal(err)
-	}
+	cfg := loadConfig()
 
 	sprites, sounds, err := loadAssets(f, sampleRate)
 	if err != nil {

--- a/neko.ini
+++ b/neko.ini
@@ -1,0 +1,2 @@
+speed=2.5
+scale=1.5


### PR DESCRIPTION
## Changes

### Multi-monitor support
Removed the per-frame position clamping that was restricting the cat to the
primary monitor. The cat now freely follows the cursor across all connected
monitors.

### Configurable speed and scale via neko.ini
Replaced the `crg.eti.br/go/config` library with a simple, direct ini parser.
The config library was silently failing to load [neko.ini](cci:7://file:///d:/neko/neko.ini:0:0-0:0) due to working
directory resolution issues. The new parser reads [neko.ini](cci:7://file:///d:/neko/neko.ini:0:0-0:0) from the same
directory as the executable — reliably, without external dependencies.

Supported keys:
- `speed` (default: `2.0`)
- `scale` (default: `2.0`)
- `quiet` (default: `false`)
- `mousepassthrough` (default: `false`)

### 🐾 Animation flicker fix
Added a 5° hysteresis dead zone at each of the 8 direction boundaries.
When the cursor angle is near a boundary between two directions, the cat
holds its last confirmed direction instead of rapidly toggling between
animations.
